### PR TITLE
Namespaced variable to avoid conflict with LwIP library.

### DIFF
--- a/Seeed_MCP9808.h
+++ b/Seeed_MCP9808.h
@@ -58,7 +58,7 @@ typedef enum {
     ERROR_PARAM = -1,
     ERROR_COMM = -2,
     ERROR_OTHERS = -128,
-} err_t;
+} mcp9808_err_t;
 
 
 #define CHECK_RESULT(a,b)   do{if(a=b)  {    \


### PR DESCRIPTION
Namespaced `err_t` variable to `mcp9808_err_t` to avoid conflict with LwIP library as used in Espressif ESP-IDF.